### PR TITLE
fix: add @types for next

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -15,6 +15,7 @@
     "zod": "^3.17.3"
   },
   "devDependencies": {
+    "@types/next": "9.0.0",
     "@types/node": "18.0.0",
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",


### PR DESCRIPTION
# add @types/next
- [x] I reviewed linter warnings + errors, resolved formatting, types, and other issues related to my work
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

Avoids Typescript whipping you out of the gate for next and next/head imports missing types